### PR TITLE
Brandon/async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 .opt-out
 .DS_Store
 .eslintcache
+__pycache__
 
 # these cause more harm than good
 # when working with contributors

--- a/src/helpers/does_user_agree.py
+++ b/src/helpers/does_user_agree.py
@@ -2,8 +2,8 @@ import time
 
 from .check_if_correct import check_if_correct
 from .set_alarm import set_alarm
-from .call_notification import call_notification
 from .manually_set_alarm import manually_set_alarm
+
 
 ##
 # does_user_agree
@@ -25,12 +25,7 @@ def does_user_agree(seconds):
     alarm_accepted = check_if_correct()
 
     if alarm_accepted == 'y':
-        curr_time  = int(time.time() * 1)
-        alarm_time = int(seconds * 1) - curr_time
-        
         print(f'\nThe alarm has been set and will go off at {time.ctime(seconds)}\n')
-        set_alarm(alarm_time)
-        call_notification()
+        set_alarm(seconds)
     elif alarm_accepted == 'n':
-        # print('\n\nSET ALARM TO PM\n\n')
         manually_set_alarm()

--- a/src/helpers/set_alarm.py
+++ b/src/helpers/set_alarm.py
@@ -1,4 +1,7 @@
+import sys
 import time
+
+from .call_notification import call_notification
 
 ##
 # set_alarm
@@ -16,4 +19,17 @@ def set_alarm(seconds):
     @return     {void}
     '''
     
-    time.sleep(seconds)
+    # time.sleep(seconds)
+    done = False
+    time_remaining = int(seconds - time.time()) * 1
+    
+    while not done:
+        time_remaining -= 1
+        
+        if time_remaining <= -1:
+            print('\n')
+            return call_notification()
+        else:
+            sys.stdout.write(f'\rAlarm will go off in {time_remaining} seconds')
+
+        time.sleep(1)

--- a/src/pylarm.py
+++ b/src/pylarm.py
@@ -1,13 +1,8 @@
 # py modules
-import subprocess
 import time
 
-
 # custom modules
-from helpers.check_if_correct import check_if_correct
 from helpers.set_alarm import set_alarm
-from helpers.call_notification import call_notification
-from helpers.manually_set_alarm import manually_set_alarm
 from helpers.does_user_agree import does_user_agree
 
 


### PR DESCRIPTION
Turns out async was not needed.

Instead, I used a while loop to check if the timer needs to go off.

If the alarm is not ready then update the terminal in place showing how much time is left until the alarm is ready (in seconds).