### PR TITLE
Add 24hr support and fix setting manual alarms.

### DIFF
--- a/src/helpers/check_if_correct.py
+++ b/src/helpers/check_if_correct.py
@@ -1,6 +1,8 @@
 ##
 # check_if_correct:
 #
+
+
 def check_if_correct():
     '''
     @summary    reusable while loop to check if alarm time is correct
@@ -15,7 +17,7 @@ def check_if_correct():
     '''
     acceptable = False
     while not acceptable:
-        alarm_accepted = input('Is this correct [Y/N]: ').lower()
+        alarm_accepted = input('Do you confirm? [Y/N]: ').lower()
 
         if alarm_accepted == 'y' or alarm_accepted == 'n':
             return alarm_accepted

--- a/src/helpers/does_user_agree.py
+++ b/src/helpers/does_user_agree.py
@@ -21,11 +21,11 @@ def does_user_agree(seconds, path):
     @param      int {seconds}
     @return     {void}
     '''
-    
+
     alarm_accepted = check_if_correct()
 
     if alarm_accepted == 'y':
         print(f'\nThe alarm has been set and will go off at {time.ctime(seconds)}\n')
         check_alarm(seconds, path)
     elif alarm_accepted == 'n':
-        manually_set_alarm()
+        manually_set_alarm(seconds, path)

--- a/src/helpers/manually_set_alarm.py
+++ b/src/helpers/manually_set_alarm.py
@@ -1,12 +1,12 @@
 import time
 
 from .check_alarm import check_alarm
-from .call_notification import call_notification
+
 
 ##
 # manually_set_alarm
 #
-def manually_set_alarm():
+def manually_set_alarm(mk_time, path):
     '''
     @summary    let the user manually set the alarm
 
@@ -21,14 +21,12 @@ def manually_set_alarm():
     @return     {void}
     '''
     # have user manually set their alarm
-    alarm_time = input('Manually set the alarm: MM DD YYYY HH:MM(am/pm)')
+    alarm_time = input('Manually set the alarm(MM DD YYYY HH:MM): ')
     # parse the alarm string into datetime tuple
-    p_alarm_time = time.strptime(alarm_time, '%m %d %Y %I:%M%p')
+    p_alarm_time = time.strptime(alarm_time, '%m %d %Y %H:%M')
     # parse datetime tuple into integer of seconds
     mk_time = time.mktime(p_alarm_time)
     # get time when alarm should go off
-    seconds_until_alarm = int(mk_time * 1) - int(time.time() * 1)
 
     print(f'\nThe alarm has been set and will go off at {time.ctime(mk_time)}\n')
-    check_alarm(seconds_until_alarm)
-    call_notification()
+    check_alarm(mk_time, path)

--- a/src/pylarm.py
+++ b/src/pylarm.py
@@ -21,46 +21,35 @@ def pylarm(path, given_time=None):
     @param      {void}
     @return     {void}
     '''
-    
-    if given_time is None:
-        alarm_time   = input('\nWhat time: ')
-    else:
-        alarm_time = given_time
+
+    alarm_time   = input('\nWhat time? (HH:MM)[24Hrs format]: ')
+
     curr_time    = time.localtime()
-    # alarm will attempt to set this for AM
-    p_alarm_time = time.strptime(f'{curr_time[1]} {curr_time[2]} {curr_time[0]} {alarm_time}am', '%m %d %Y %I:%M%p')
+    
+    p_alarm_time = time.strptime(f'{curr_time[1]} {curr_time[2]} {curr_time[0]} {alarm_time}', '%m %d %Y %H:%M')
     mk_time      = time.mktime(p_alarm_time)
 
-    if int(mk_time * 1000) <= int(time.time() * 1000):
-        # use the same values but for PM
-        p_alarm_time = time.strptime(f'{curr_time[1]} {curr_time[2]} {curr_time[0]} {alarm_time}pm', '%m %d %Y %I:%M%p')
+    if curr_time[3]<int(alarm_time[0]+alarm_time[1]):
+        p_alarm_time = time.strptime(f'{curr_time[1]} {curr_time[2]} {curr_time[0]} {alarm_time}', '%m %d %Y %H:%M')
         mk_time      = time.mktime(p_alarm_time)
+        does_user_agree(mk_time, path)
 
-        if int(mk_time * 1000) <= int(time.time() * 1000):
-            '''
-            an error occurs at the end of each month where Pylarm attempts to set the day, curr_time[2], to a day
-            that doesnt exist in that month, e.g. January 32
-            this try/except will catch that error and increase the month by 1 and reset the day to 1
-            i.e. January 32 => February 1
-            '''
-            try:
-                # use the original values in the AM but for the next day: curr_time[2] + 1
-                p_alarm_time = time.strptime(f'{curr_time[1]} {curr_time[2] + 1} {curr_time[0]} {alarm_time}pm', '%m %d %Y %I:%M%p')
-
-            except:
-                p_alarm_time = time.strptime(f'{curr_time[1] + 1} 01 {curr_time[0]} {alarm_time}pm', '%m %d %Y %I:%M%p')
-
-            
-            mk_time = time.mktime(p_alarm_time)
-
-            print(f'\nThe alarm is set to go off at {time.ctime(mk_time)}\n\n')
-
+    elif curr_time[3]==int(alarm_time[0]+alarm_time[1]):
+        if curr_time[4]<=int(alarm_time[3]+alarm_time[4]):
+            p_alarm_time = time.strptime(f'{curr_time[1]} {curr_time[2]} {curr_time[0]} {alarm_time}', '%m %d %Y %H:%M')
+            mk_time      = time.mktime(p_alarm_time)
             does_user_agree(mk_time, path)
 
-        # if setting alarm to PM allowed
-        # check if user is okay with this time
-        # e.g. August 25 2018 4:40pm
         else:
+            p_alarm_time = time.strptime(f'{curr_time[1]} {curr_time[2]+1} {curr_time[0]} {alarm_time}', '%m %d %Y %H:%M')
+            mk_time      = time.mktime(p_alarm_time)
             does_user_agree(mk_time, path)
+
+
+
+
     else:
+        p_alarm_time = time.strptime(f'{curr_time[1]} {curr_time[2]+1} {curr_time[0]} {alarm_time}', '%m %d %Y %H:%M')
+        mk_time = time.mktime(p_alarm_time)
+
         does_user_agree(mk_time, path)


### PR DESCRIPTION
Closes #19
The file pylarm.py has been edited with a much
simpler code which is easier to read and
functions much more simply so that now the alarm
works in 24Hrs format.If the user sets alarm which is before
his local time, then the alarm automaatically sets the alarm
for the next day.If the user sets alarm for a time which is yet to
come on that day,i.e. after the local time,then the alarm sets itself
for that day only.
If the user isn't satisfied with the final time, he can manually set it.
The file manually_set_alarm.py has been edited and debugged
to add new parameters to manually_set_alarm function

### PR Check list
- [ ] I am pulling from my own branch and **not** a master branch
- [ ] My branch is named appropriately: `<your_name>/<issue_num>_<type>_<branch-name>`
- [ ] Commit messages are detailed and reference file(s) changed
- [ ] If applicable, I am referencing or closing an open issue: `ref #1`


### Pull Request Description


### Screenshots (if any)